### PR TITLE
reorg of agent related artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ ehthumbs.db
 Thumbs.db
 Desktop.ini
 $RECYCLE.BIN/
-
+**/ideas/
 # Linux
 *~
 .directory


### PR DESCRIPTION
This reorg was to better separate concerns. All agent related defintions, patterns, scripts are under the ./agents.