### PR TITLE
filtering now applied based on language, domain, and tags before simi…

### DIFF
--- a/src/mnemonic/internal/mcpserver/handlers.go
+++ b/src/mnemonic/internal/mcpserver/handlers.go
@@ -58,6 +58,8 @@ func handleSearchPatterns(deps ToolDependencies, logger zerolog.Logger) mcp.Tool
 			Threshold: threshold,
 			Tags:      input.Tags,
 			AgentName: input.Agent,
+			Language:  input.Language,
+			Domain:    input.Domain,
 		})
 		if err != nil {
 			return nil, nil, mapServiceError(err)

--- a/src/mnemonic/internal/mcpserver/handlers_test.go
+++ b/src/mnemonic/internal/mcpserver/handlers_test.go
@@ -59,12 +59,6 @@ func noopLogger() zerolog.Logger {
 	return zerolog.Nop()
 }
 
-// intPtr returns a pointer to the given int.
-func intPtr(v int) *int { return &v }
-
-// float64Ptr returns a pointer to the given float64.
-func float64Ptr(v float64) *float64 { return &v }
-
 // extractTextContent extracts the text string from a CallToolResult's Content.
 func extractTextContent(t *testing.T, result *mcp.CallToolResult) string {
 	t.Helper()
@@ -187,9 +181,10 @@ func TestHandleSearchPatterns_InvalidLimit(t *testing.T) {
 	deps := new(mockToolDeps)
 	handler := handleSearchPatterns(deps, noopLogger())
 
+	limit := 100
 	_, _, err := handler(context.Background(), nil, SearchPatternsInput{
 		Query: "anything",
-		Limit: intPtr(100),
+		Limit: &limit,
 	})
 
 	require.Error(t, err)
@@ -203,9 +198,10 @@ func TestHandleSearchPatterns_InvalidThreshold(t *testing.T) {
 	deps := new(mockToolDeps)
 	handler := handleSearchPatterns(deps, noopLogger())
 
+	threshold := 1.5
 	_, _, err := handler(context.Background(), nil, SearchPatternsInput{
 		Query:     "anything",
-		Threshold: float64Ptr(1.5),
+		Threshold: &threshold,
 	})
 
 	require.Error(t, err)
@@ -229,10 +225,12 @@ func TestHandleSearchPatterns_CustomLimitAndThreshold(t *testing.T) {
 		Threshold: 0.9,
 	}).Return(searchResult, nil)
 
+	limit := 5
+	threshold := 0.9
 	result, _, err := handler(context.Background(), nil, SearchPatternsInput{
 		Query:     "go patterns",
-		Limit:     intPtr(5),
-		Threshold: float64Ptr(0.9),
+		Limit:     &limit,
+		Threshold: &threshold,
 	})
 
 	require.NoError(t, err)
@@ -267,15 +265,70 @@ func TestHandleSearchPatterns_WithTags(t *testing.T) {
 	deps.AssertExpectations(t)
 }
 
+func TestHandleSearchPatterns_WithLanguageFilter(t *testing.T) {
+	t.Parallel()
+
+	deps := new(mockToolDeps)
+	handler := handleSearchPatterns(deps, noopLogger())
+
+	searchResult := &searchsvc.SearchResult{
+		Query:   "error handling",
+		Matches: []*searchsvc.ChunkMatch{},
+	}
+	deps.On("SearchPatterns", mock.Anything, searchsvc.SearchOptions{
+		Query:     "error handling",
+		Limit:     10,
+		Threshold: 0.7,
+		Language:  "python",
+	}).Return(searchResult, nil)
+
+	result, _, err := handler(context.Background(), nil, SearchPatternsInput{
+		Query:    "error handling",
+		Language: "python",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	deps.AssertExpectations(t)
+}
+
+func TestHandleSearchPatterns_WithDomainFilter(t *testing.T) {
+	t.Parallel()
+
+	deps := new(mockToolDeps)
+	handler := handleSearchPatterns(deps, noopLogger())
+
+	searchResult := &searchsvc.SearchResult{
+		Query:   "error handling",
+		Matches: []*searchsvc.ChunkMatch{},
+	}
+	deps.On("SearchPatterns", mock.Anything, searchsvc.SearchOptions{
+		Query:     "error handling",
+		Limit:     10,
+		Threshold: 0.7,
+		Domain:    "backend",
+	}).Return(searchResult, nil)
+
+	result, _, err := handler(context.Background(), nil, SearchPatternsInput{
+		Query:  "error handling",
+		Domain: "backend",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	deps.AssertExpectations(t)
+}
+
 func TestHandleSearchPatterns_ZeroLimit(t *testing.T) {
 	t.Parallel()
 
 	deps := new(mockToolDeps)
 	handler := handleSearchPatterns(deps, noopLogger())
 
+	limit := 0
 	_, _, err := handler(context.Background(), nil, SearchPatternsInput{
 		Query: "anything",
-		Limit: intPtr(0),
+		Limit: &limit,
 	})
 
 	require.Error(t, err)
@@ -288,9 +341,10 @@ func TestHandleSearchPatterns_NegativeThreshold(t *testing.T) {
 	deps := new(mockToolDeps)
 	handler := handleSearchPatterns(deps, noopLogger())
 
+	threshold := -0.1
 	_, _, err := handler(context.Background(), nil, SearchPatternsInput{
 		Query:     "anything",
-		Threshold: float64Ptr(-0.1),
+		Threshold: &threshold,
 	})
 
 	require.Error(t, err)
@@ -404,9 +458,10 @@ func TestHandleFindRelatedPatterns_InvalidLimit(t *testing.T) {
 	deps := new(mockToolDeps)
 	handler := handleFindRelatedPatterns(deps, noopLogger())
 
+	limit := 25
 	_, _, err := handler(context.Background(), nil, FindRelatedPatternsInput{
 		PatternID: uuid.New().String(),
-		Limit:     intPtr(25),
+		Limit:     &limit,
 	})
 
 	require.Error(t, err)
@@ -430,9 +485,10 @@ func TestHandleFindRelatedPatterns_CustomLimit(t *testing.T) {
 		Return([]patternsvc.RelatedPatternResult{}, nil)
 	deps.On("GetPatternWithGraph", mock.Anything, patternID).Return(sourcePattern, nil, nil)
 
+	limit := 10
 	result, _, err := handler(context.Background(), nil, FindRelatedPatternsInput{
 		PatternID: patternID.String(),
-		Limit:     intPtr(10),
+		Limit:     &limit,
 	})
 
 	require.NoError(t, err)

--- a/src/mnemonic/internal/mcpserver/input.go
+++ b/src/mnemonic/internal/mcpserver/input.go
@@ -16,6 +16,8 @@ type SearchPatternsInput struct {
 	Threshold *float64 `json:"threshold,omitempty" jsonschema:"Minimum cosine similarity score 0.0-1.0 (default 0.7)"`
 	Tags      []string `json:"tags,omitempty"      jsonschema:"Conjunctive (AND) filter by tag. Pattern must contain ALL specified tags."`
 	Agent     string   `json:"agent,omitempty"     jsonschema:"Filter results by agent association"`
+	Language  string   `json:"language,omitempty"  jsonschema:"Optional: filter results by pattern language (e.g. 'go', 'python')"`
+	Domain    string   `json:"domain,omitempty"    jsonschema:"Optional: filter results by pattern domain (e.g. 'backend', 'testing')"`
 }
 
 // FindRelatedPatternsInput defines the parameters for the find_related_patterns tool.

--- a/src/mnemonic/internal/service/pattern/service.go
+++ b/src/mnemonic/internal/service/pattern/service.go
@@ -170,57 +170,51 @@ func New(
 	}
 }
 
-// splitChunk is a parsed chunk from content.
-type splitChunk struct {
-	SectionTitle string
-	ChunkIndex   int
-	Content      string
+// chunk is a parsed chunk from content.
+type chunk struct {
+	Title   string
+	Content string
 }
 
-// splitIntoChunks splits markdown content at H2 (##) boundaries.
-// Content before the first H2 becomes an "Overview" chunk.
-// Content with no H2 headings becomes a single "Content" chunk.
-// Empty sections are dropped.
-func splitIntoChunks(content string) []splitChunk {
-	lines := strings.Split(content, "\n")
-	var chunks []splitChunk
+// splitIntoChunks parses markdown content and returns a chunk for each section
+// preceded by a "[//]: pattern" decorator line. The heading following the
+// decorator becomes the chunk title; all subsequent lines until the next
+// decorator (or EOF) form the body. Lines outside decorated sections are
+// discarded.
+func splitIntoChunks(content string) []chunk {
+	var chunks []chunk
 	var currentTitle string
 	var currentLines []string
-	index := 0
+	pendingPattern := false
 
-	flush := func(title string) {
-		body := strings.TrimSpace(strings.Join(currentLines, "\n"))
-		if body == "" {
+	flush := func() {
+		if currentTitle == "" {
 			return
 		}
-		chunks = append(chunks, splitChunk{
-			SectionTitle: title,
-			ChunkIndex:   index,
-			Content:      body,
-		})
-		index++
+		body := strings.TrimSpace(strings.Join(currentLines, "\n"))
+		if body != "" {
+			chunks = append(chunks, chunk{Title: currentTitle, Content: body})
+		}
+		currentTitle = ""
+		currentLines = nil
 	}
 
-	foundH2 := false
-	for _, line := range lines {
-		if strings.HasPrefix(line, "## ") {
-			if !foundH2 {
-				flush("Overview")
-				foundH2 = true
-			} else {
-				flush(currentTitle)
-			}
-			currentTitle = strings.TrimPrefix(line, "## ")
+	for line := range strings.SplitSeq(content, "\n") {
+		if line == "[//]: pattern" {
+			flush()
+			pendingPattern = true
+		} else if pendingPattern && strings.HasPrefix(line, "#") {
+			title := strings.TrimSpace(strings.TrimLeft(line, "#"))
+			currentTitle = title
 			currentLines = nil
-		} else {
+			pendingPattern = false
+		} else if currentTitle != "" {
 			currentLines = append(currentLines, line)
 		}
+		// else: outside any decorated section — discard line
 	}
-	if foundH2 {
-		flush(currentTitle)
-	} else {
-		flush("Content")
-	}
+	flush()
+
 	return chunks
 }
 
@@ -266,8 +260,8 @@ func (s *patternService) Create(ctx context.Context, input CreateInput) (*patter
 		for i, rc := range rawChunks {
 			chunks[i] = &chunkrepo.Chunk{
 				PatternID:    pattern.ID,
-				SectionTitle: rc.SectionTitle,
-				ChunkIndex:   rc.ChunkIndex,
+				SectionTitle: rc.Title,
+				ChunkIndex:   i,
 				Content:      rc.Content,
 			}
 		}
@@ -502,8 +496,8 @@ func (s *patternService) updateWithTransaction(
 	for i, rc := range rawChunks {
 		newChunks[i] = &chunkrepo.Chunk{
 			PatternID:    existing.ID,
-			SectionTitle: rc.SectionTitle,
-			ChunkIndex:   rc.ChunkIndex,
+			SectionTitle: rc.Title,
+			ChunkIndex:   i,
 			Content:      rc.Content,
 		}
 	}

--- a/src/mnemonic/internal/service/pattern/service_test.go
+++ b/src/mnemonic/internal/service/pattern/service_test.go
@@ -935,7 +935,7 @@ func TestUpdate(t *testing.T) {
 
 		input := patternsvc.UpdateInput{
 			Name:    "go-error-handling-v2",
-			Content: "## Section One\nNew content.\n\n## Section Two\nMore new content.",
+			Content: "[//]: pattern\n## Section One\nNew content.\n\n[//]: pattern\n## Section Two\nMore new content.",
 			Tags:    []string{"golang", "errors"},
 		}
 
@@ -957,7 +957,7 @@ func TestUpdate(t *testing.T) {
 		// Chunk-aware path: delete stale chunks.
 		cr.On("DeleteByPatternID", mock.Anything, testPatternID).Return(nil)
 
-		// Create new chunks (content has 2 H2 sections → 2 chunks).
+		// Create new chunks (content has 2 PATTERN sections → 2 chunks).
 		cr.On("CreateBatch", mock.Anything, mock.MatchedBy(func(chunks []*chunkrepo.Chunk) bool {
 			return len(chunks) == 2
 		})).Return(nil)
@@ -1040,7 +1040,7 @@ func TestCreate_ChunkJobFailuresSummarisedInLog(t *testing.T) {
 
 	input := patternsvc.CreateInput{
 		Name:    "go-error-handling",
-		Content: "## Section One\nContent one.\n\n## Section Two\nContent two.",
+		Content: "[//]: pattern\n## Section One\nContent one.\n\n[//]: pattern\n## Section Two\nContent two.",
 	}
 
 	pr.On("Create", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
@@ -1086,7 +1086,7 @@ func TestUpdate_ChunkJobFailuresSummarisedInLog(t *testing.T) {
 
 	input := patternsvc.UpdateInput{
 		Name:    "go-error-handling-v2",
-		Content: "## Section One\nContent one.\n\n## Section Two\nContent two.",
+		Content: "[//]: pattern\n## Section One\nContent one.\n\n[//]: pattern\n## Section Two\nContent two.",
 	}
 
 	tb.On("Begin", mock.Anything).Return(tx, nil)
@@ -1509,8 +1509,8 @@ func TestCreate_ChunksContent(t *testing.T) {
 		input := patternsvc.CreateInput{
 			Name:        "chunked-pattern",
 			Description: &desc,
-			// Two H2 sections → 2 chunks.
-			Content:    "## Section One\nContent of section one.\n\n## Section Two\nContent of section two.",
+			// Two decorated sections → 2 chunks.
+			Content:    "[//]: pattern\n## Section One\nContent of section one.\n\n[//]: pattern\n## Section Two\nContent of section two.",
 			Tags:       []string{"test"},
 			EntityType: "go-pattern",
 			Language:   "go",

--- a/src/mnemonic/internal/service/pattern/split_chunks_test.go
+++ b/src/mnemonic/internal/service/pattern/split_chunks_test.go
@@ -1,73 +1,81 @@
-// White-box test file: accesses unexported splitIntoChunks directly.
 package pattern
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestSplitChunks_ByH2Heading(t *testing.T) {
-	content := "## Philosophy\nStorage-only databases.\n\n## created_at Handling\nLet the database set it.\n\n## updated_at Handling\nAlways set explicitly."
-	chunks := splitIntoChunks(content)
-	require.Len(t, chunks, 3)
-	assert.Equal(t, "Philosophy", chunks[0].SectionTitle)
-	assert.Equal(t, 0, chunks[0].ChunkIndex)
-	assert.Contains(t, chunks[0].Content, "Storage-only")
-	assert.Equal(t, "updated_at Handling", chunks[2].SectionTitle)
-	assert.Equal(t, 2, chunks[2].ChunkIndex)
-}
+func Test_splitIntoChunks(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantLen    int
+		wantTitles []string
+	}{
+		{
+			name:       "single decorated section",
+			input:      "[//]: pattern\n## When to Use AsyncAPI\n\n- Event-driven architectures",
+			wantLen:    1,
+			wantTitles: []string{"When to Use AsyncAPI"},
+		},
+		{
+			name:       "multiple decorated sections",
+			input:      "[//]: pattern\n## Section A\ncontent A\n[//]: pattern\n## Section B\ncontent B",
+			wantLen:    2,
+			wantTitles: []string{"Section A", "Section B"},
+		},
+		{
+			name:       "non-decorated heading ignored",
+			input:      "## Overview\nsome text\n[//]: pattern\n## Foo\ncontent",
+			wantLen:    1,
+			wantTitles: []string{"Foo"},
+		},
+		{
+			name:       "preamble before first decorator ignored",
+			input:      "# Title\n\nsome intro\n\n[//]: pattern\n## Foo\ncontent",
+			wantLen:    1,
+			wantTitles: []string{"Foo"},
+		},
+		{
+			name:    "no decorators",
+			input:   "## Overview\ntext",
+			wantLen: 0,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantLen: 0,
+		},
+		{
+			name:       "empty decorated body dropped",
+			input:      "[//]: pattern\n## Empty\n\n[//]: pattern\n## Real\ncontent",
+			wantLen:    1,
+			wantTitles: []string{"Real"},
+		},
+		{
+			name:       "title extracted correctly from h2",
+			input:      "[//]: pattern\n## Configuration Precedence Order\nsome content",
+			wantLen:    1,
+			wantTitles: []string{"Configuration Precedence Order"},
+		},
+		{
+			name:       "h3 heading also works",
+			input:      "[//]: pattern\n### Deep Section\nsome content",
+			wantLen:    1,
+			wantTitles: []string{"Deep Section"},
+		},
+	}
 
-func TestSplitChunks_NoH2_SingleChunk(t *testing.T) {
-	content := "Just a paragraph with no headings."
-	chunks := splitIntoChunks(content)
-	require.Len(t, chunks, 1)
-	assert.Equal(t, "Content", chunks[0].SectionTitle)
-	assert.Equal(t, content, chunks[0].Content)
-}
-
-func TestSplitChunks_ContentBeforeFirstH2(t *testing.T) {
-	content := "Preamble text here.\n\n## First Section\nSection content."
-	chunks := splitIntoChunks(content)
-	require.Len(t, chunks, 2)
-	assert.Equal(t, "Overview", chunks[0].SectionTitle)
-	assert.Contains(t, chunks[0].Content, "Preamble")
-	assert.Equal(t, "First Section", chunks[1].SectionTitle)
-}
-
-func TestSplitChunks_EmptySectionDropped(t *testing.T) {
-	content := "## Empty\n\n## Real Section\nActual content here."
-	chunks := splitIntoChunks(content)
-	require.Len(t, chunks, 1)
-	assert.Equal(t, "Real Section", chunks[0].SectionTitle)
-	assert.Equal(t, 0, chunks[0].ChunkIndex)
-}
-
-func TestSplitChunks_EmptyString(t *testing.T) {
-	chunks := splitIntoChunks("")
-	require.Len(t, chunks, 0)
-}
-
-func TestSplitChunks_SingleH2WithContent(t *testing.T) {
-	content := "## Only Section\nSome content here."
-	chunks := splitIntoChunks(content)
-	require.Len(t, chunks, 1)
-	assert.Equal(t, "Only Section", chunks[0].SectionTitle)
-	assert.Equal(t, 0, chunks[0].ChunkIndex)
-	assert.Equal(t, "Some content here.", chunks[0].Content)
-}
-
-func TestSplitChunks_H2TrailingWhitespace(t *testing.T) {
-	content := "## Section With Spaces   \nContent here."
-	chunks := splitIntoChunks(content)
-	require.Len(t, chunks, 1)
-	// TrimPrefix leaves trailing whitespace — section title should match raw suffix.
-	assert.Equal(t, "Section With Spaces   ", chunks[0].SectionTitle)
-	assert.Equal(t, "Content here.", chunks[0].Content)
-}
-
-func TestSplitChunks_WhitespaceOnlyContent(t *testing.T) {
-	chunks := splitIntoChunks("   \n\t\n  ")
-	require.Len(t, chunks, 0)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitIntoChunks(tt.input)
+			assert.Len(t, got, tt.wantLen)
+			for i, title := range tt.wantTitles {
+				if i < len(got) {
+					assert.Equal(t, title, got[i].Title)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
  Summary

  This PR fixes two related gaps in the pattern search pipeline:

  1. `[//]: pattern` decorator-driven chunking — the splitIntoChunks function previously split content at every ##  boundary, producing noisy chunks from overview text and section headers that aren't standalone patterns. It now only
   chunks sections explicitly marked with a [//]: pattern decorator line. Unmarked sections are discarded. This gives pattern authors precise control over what enters the vector index.
  2. Language and domain filters exposed on search_patterns MCP tool — SearchPatternsInput gains language and domain fields, which are passed through to SearchOptions. The SQL-level filtering was already wired at the repository
  layer; this change closes the gap so agents can actually use it (e.g. searching for "error handling" in go only).

  Changes

  - mcpserver/input.go — add Language and Domain to SearchPatternsInput
  - mcpserver/handlers.go — pass new fields into SearchOptions
  - service/pattern/service.go — rewrite splitIntoChunks to use decorator-based chunking
  - *_test.go — updated tests for new chunking behavior; added filter pass-through tests; removed pre-existing intPtr/float64Ptr helper wrappers flagged by linter

  Test plan
  - go test ./... passes (all 34 packages)
  - Searching with language: "go" returns only Go patterns
  - Searching with domain: "testing" returns only testing-domain patterns
  - Patterns without [//]: pattern markers produce no chunks