### PR TITLE
docs: update embedding model references from text-embedding-3-small/1536 to text-embedding-3-large/2000

### DIFF
--- a/docs/architecture/04-data-architecture.md
+++ b/docs/architecture/04-data-architecture.md
@@ -121,7 +121,7 @@ graph TB
 
 **Stores:**
 
-- Pattern chunk embeddings (one vector per H2 section, 1536 dimensions, OpenAI text-embedding-3-small)
+- Pattern chunk embeddings (one vector per H2 section, 2000 dimensions, OpenAI text-embedding-3-large)
 - Prompt embeddings for semantic search (generated at query time)
 
 **Why PGVector over Dedicated Vector DB:**
@@ -206,7 +206,7 @@ erDiagram
         string section_title
         int chunk_index
         text content
-        vector embedding "1536 dimensions"
+        vector embedding "2000 dimensions"
         enum enrichment_status "pending|enriched|failed"
         text enrichment_error
         timestamptz enriched_at
@@ -269,7 +269,7 @@ Patterns use relational columns (not JSONB) for enrichment tracking and metadata
 
 **Schema:** Columns include `id`, `name`, `description`, `content`, `tags` (JSONB), `entity_type`, `language`, `domain`, `version`, `related_patterns` (JSONB), `enrichment_status`, `enrichment_error`, `enriched_at`, `created_at`, `updated_at`. The `embedding` column was removed in migration 000009; vector embeddings now live in `pattern_chunks`.
 
-**Pattern chunks:** Each pattern is split at H2 headings into one or more rows in `pattern_chunks`. Each chunk holds its own `embedding vector(1536)` for section-level semantic search. If a pattern has no H2 headings it is stored as a single chunk. The `enrichment_status` on the pattern reflects aggregate chunk status: a pattern is `enriched` when all its chunks are enriched.
+**Pattern chunks:** Each pattern is split at H2 headings into one or more rows in `pattern_chunks`. Each chunk holds its own `embedding vector(2000)` for section-level semantic search. If a pattern has no H2 headings it is stored as a single chunk. The `enrichment_status` on the pattern reflects aggregate chunk status: a pattern is `enriched` when all its chunks are enriched.
 
 **Enrichment States:**
 
@@ -495,7 +495,7 @@ sequenceDiagram
     WORKER->>WORKER: Split content at H2 headings into chunks
     loop For each chunk
         WORKER->>OPENAI: Generate chunk embedding
-        OPENAI-->>WORKER: vector(1536)
+        OPENAI-->>WORKER: vector(2000)
         WORKER->>PGV: Store chunk embedding in pattern_chunks
     end
     WORKER->>OPENAI: Extract entities from full content (LLM)
@@ -538,7 +538,7 @@ sequenceDiagram
 
     CC->>MCP: search_patterns(query)
     MCP->>OPENAI: Generate query embedding
-    OPENAI-->>MCP: vector(1536)
+    OPENAI-->>MCP: vector(2000)
     MCP->>PGV: Chunk-level semantic search (pattern_chunks)
     PGV-->>MCP: ChunkMatch results
     MCP-->>CC: Chunk results (section_title, pattern metadata)

--- a/docs/architecture/05-database-integration-flow.md
+++ b/docs/architecture/05-database-integration-flow.md
@@ -44,7 +44,7 @@ Each database serves a distinct purpose in the Mnemonic architecture:
 
 **Stores:**
 
-- Pattern content embeddings (1536 dimensions, OpenAI text-embedding-3-small)
+- Pattern content embeddings (2000 dimensions, OpenAI text-embedding-3-large)
 - Vector similarity indexes (IVFFlat or HNSW based on scale)
 
 **Why PGVector:** Single database deployment (no separate vector service), transactional consistency with metadata, and sufficient performance for expected pattern counts.
@@ -81,7 +81,7 @@ flowchart TB
 
         subgraph PGVector["PGVector (Vectors)"]
             PV1["patterns.embedding"]
-            PV2["(1536-dim)"]
+            PV2["(2000-dim)"]
             PV3["Cosine distance"]
             PV4["similarity"]
             PV5["Semantic Search"]
@@ -114,7 +114,7 @@ name: VARCHAR(128)
 description: VARCHAR(500)
 content: TEXT (up to 10KB)
 tags: JSONB
-embedding: vector(1536)
+embedding: vector(2000)
 enrichment_status: ENUM ('pending', 'enriched', 'failed')
 enriched_at: TIMESTAMPTZ
 ```
@@ -125,7 +125,7 @@ enriched_at: TIMESTAMPTZ
 id: 550e8400-e29b-41d4-a716-446655440001
 name: "sql-query-optimization"
 content: "Use EXPLAIN ANALYZE to identify slow queries..."
-embedding: vector(1536) [0.023, -0.145, ...]
+embedding: vector(2000) [0.023, -0.145, ...]
 enrichment_status: 'enriched'
 ```
 
@@ -215,10 +215,10 @@ FOR UPDATE SKIP LOCKED;
 ```go
 // Call OpenAI embedding API
 embedding := openai.CreateEmbedding(
-  model: "text-embedding-3-small",
+  model: "text-embedding-3-large",
   input: pattern.Content,
 )
-// Returns: vector(1536) [0.023, -0.145, 0.087, ...]
+// Returns: vector(2000) [0.023, -0.145, 0.087, ...]
 ```
 
 **Step 4: Store Embedding (PGVector)**
@@ -312,10 +312,10 @@ This is the core operation: turning an MCP tool call into a knowledge graph quer
 ```go
 // Generate embedding for search query
 queryEmbedding := openai.CreateEmbedding(
-  model: "text-embedding-3-small",
+  model: "text-embedding-3-large",
   input: "How do I optimize SQL queries?",
 )
-// Returns: vector(1536)
+// Returns: vector(2000)
 ```
 
 **Step 2: Semantic Search (PGVector Similarity Search)**
@@ -420,7 +420,7 @@ While not part of the MVP, there's an interesting opportunity to visualize the e
 
 **The Idea:**
 
-Use dimensionality reduction techniques (t-SNE, UMAP) to project the 1536-dimensional embeddings down to 3D space for interactive visualization.
+Use dimensionality reduction techniques (t-SNE, UMAP) to project the 2000-dimensional embeddings down to 3D space for interactive visualization.
 
 **What You Could See:**
 

--- a/docs/design/configuration.md
+++ b/docs/design/configuration.md
@@ -157,8 +157,8 @@ database:
 openai:
   # API key should be set via MNEMONIC_OPENAI_API_KEY
   api_key: ""
-  embedding_model: text-embedding-3-small
-  embedding_dimensions: 1536
+  embedding_model: text-embedding-3-large
+  embedding_dimensions: 2000
   extraction_model: gpt-4o-mini
   max_requests_per_minute: 500
   retry_attempts: 3
@@ -328,8 +328,8 @@ The otelx package handles the complexity of OpenTelemetry SDK setup, allowing Mn
 | `database.neo4j.max_connection_pool_size`       | int      | `50`                     | `MNEMONIC_DATABASE_NEO4J_MAX_CONNECTION_POOL_SIZE`       | Neo4j max connection pool size                                                              |
 | `database.neo4j.connection_acquisition_timeout` | duration | `60s`                    | `MNEMONIC_DATABASE_NEO4J_CONNECTION_ACQUISITION_TIMEOUT` | Neo4j connection acquisition timeout                                                        |
 | `openai.api_key`                                | string   | `""`                     | `MNEMONIC_OPENAI_API_KEY`                                | OpenAI API key                                                                              |
-| `openai.embedding_model`                        | string   | `text-embedding-3-small` | `MNEMONIC_OPENAI_EMBEDDING_MODEL`                        | Embedding model                                                                             |
-| `openai.embedding_dimensions`                   | int      | `1536`                   | `MNEMONIC_OPENAI_EMBEDDING_DIMENSIONS`                   | Embedding dimensions                                                                        |
+| `openai.embedding_model`                        | string   | `text-embedding-3-large` | `MNEMONIC_OPENAI_EMBEDDING_MODEL`                        | Embedding model                                                                             |
+| `openai.embedding_dimensions`                   | int      | `2000`                   | `MNEMONIC_OPENAI_EMBEDDING_DIMENSIONS`                   | Embedding dimensions                                                                        |
 | `openai.extraction_model`                       | string   | `gpt-4o-mini`            | `MNEMONIC_OPENAI_EXTRACTION_MODEL`                       | Entity extraction model                                                                     |
 | `rate_limit.enabled`                            | bool     | `false`                  | `MNEMONIC_RATE_LIMIT_ENABLED`                            | Enable rate limiting (Post-MVP)                                                             |
 | `rate_limit.requests_per_second`                | int      | `100`                    | `MNEMONIC_RATE_LIMIT_REQUESTS_PER_SECOND`                | Global RPS limit (Post-MVP)                                                                 |
@@ -488,8 +488,8 @@ func setDefaults(v *viper.Viper) {
     v.SetDefault("database.neo4j.connection_acquisition_timeout", "60s")
 
     // OpenAI defaults
-    v.SetDefault("openai.embedding_model", "text-embedding-3-small")
-    v.SetDefault("openai.embedding_dimensions", 1536)
+    v.SetDefault("openai.embedding_model", "text-embedding-3-large")
+    v.SetDefault("openai.embedding_dimensions", 2000)
     v.SetDefault("openai.extraction_model", "gpt-4o-mini")
     v.SetDefault("openai.max_requests_per_minute", 500)
     v.SetDefault("openai.retry_attempts", 3)
@@ -639,18 +639,18 @@ Error: configuration validation failed:
 
 ```text
 # Example dimension mismatch error
-FATAL: embedding dimension mismatch: config specifies 3072 dimensions but PGVector column is defined as vector(1536)
+FATAL: embedding dimension mismatch: config specifies 3072 dimensions but PGVector column is defined as vector(2000)
 ```
 
 **Failure mode without validation**: If dimension validation were skipped, the system would fail at runtime with cryptic Postgres errors when attempting to store embeddings:
 
 ```text
-ERROR: expected 1536 dimensions, not 3072 (SQLSTATE XX000)
+ERROR: expected 2000 dimensions, not 3072 (SQLSTATE XX000)
 ```
 
 This error occurs during pattern enrichment, making it difficult to diagnose as a configuration issue.
 
-**Schema migration required**: Changing the `embedding_dimensions` setting (for example, when switching from `text-embedding-ada-002` with 1536 dimensions to `text-embedding-3-large` with 3072 dimensions) requires a database schema migration:
+**Schema migration required**: Changing the `embedding_dimensions` setting (for example, when switching from `text-embedding-3-large` with 2000 dimensions to `text-embedding-3-large` with 3072 dimensions) requires a database schema migration:
 
 1. Update the PGVector column definition to match the new dimensions
 2. Re-generate embeddings for all existing patterns

--- a/docs/design/data-storage.md
+++ b/docs/design/data-storage.md
@@ -402,8 +402,8 @@ create table if not exists patterns (
     -- Categorization tags (JSON array)
     tags jsonb not null default '[]'::jsonb,
 
-    -- Vector embedding for semantic search (1536 dimensions for text-embedding-3-small)
-    embedding vector(1536),
+    -- Vector embedding for semantic search (2000 dimensions for text-embedding-3-large)
+    embedding vector(2000),
 
     -- Enrichment processing state
     enrichment_status varchar(20) not null default 'pending',
@@ -425,7 +425,7 @@ create table if not exists patterns (
 );
 
 comment on table patterns is 'Reusable context patterns for prompt enrichment';
-comment on column patterns.embedding is 'Vector embedding (1536d) for semantic similarity search';
+comment on column patterns.embedding is 'Vector embedding (2000d) for semantic similarity search';
 comment on column patterns.enrichment_status is 'Processing state: pending, enriched, or failed';
 ```
 


### PR DESCRIPTION
## Summary

- Updates all documentation references from `text-embedding-3-small`/`1536` to `text-embedding-3-large`/`2000` to match current defaults in `src/mnemonic/internal/config/defaults.go`
- Fixes sequence diagrams, code examples, schema definitions, and configuration tables across 4 docs files

Fixes #72

🤖 Generated with [Claude Code](https://claude.ai/claude-code)