### PR TITLE
docs: fix default search threshold from 0.7 to 0.5

### DIFF
--- a/docs/architecture/08-mcp-tools.md
+++ b/docs/architecture/08-mcp-tools.md
@@ -51,7 +51,7 @@ Semantic search over the team knowledge graph.
 | ----------- | ------------ | -------- | ------- | ----------- | ------------------------------------ |
 | `query`     | string       | yes      | —       | —           | Natural language search query        |
 | `limit`     | integer      | no       | 10      | max 50      | Maximum number of results to return  |
-| `threshold` | number       | no       | 0.7     | 0.0–1.0     | Minimum cosine similarity score      |
+| `threshold` | number       | no       | 0.5     | 0.0–1.0     | Minimum cosine similarity score      |
 | `tags`      | string array | no       | —       | —           | Conjunctive (AND) filter by tag      |
 | `agent`     | string       | no       | —       | —           | Filter results by agent association  |
 

--- a/src/mnemonic/internal/mcpserver/input.go
+++ b/src/mnemonic/internal/mcpserver/input.go
@@ -13,7 +13,7 @@ package mcpserver
 type SearchPatternsInput struct {
 	Query     string   `json:"query"              jsonschema:"Natural language search query"`
 	Limit     *int     `json:"limit,omitempty"    jsonschema:"Maximum number of results to return (default 10, max 50)"`
-	Threshold *float64 `json:"threshold,omitempty" jsonschema:"Minimum cosine similarity score 0.0-1.0 (default 0.7)"`
+	Threshold *float64 `json:"threshold,omitempty" jsonschema:"Minimum cosine similarity score 0.0-1.0 (default 0.5)"`
 	Tags      []string `json:"tags,omitempty"      jsonschema:"Conjunctive (AND) filter by tag. Pattern must contain ALL specified tags."`
 	Agent     string   `json:"agent,omitempty"     jsonschema:"Filter results by agent association"`
 	Language  string   `json:"language,omitempty"  jsonschema:"Optional: filter results by pattern language (e.g. 'go', 'python')"`


### PR DESCRIPTION
## Summary

- Fix default search threshold documented as `0.7` → correct value `0.5` in `docs/architecture/08-mcp-tools.md` parameter table
- Fix jsonschema description tag on `Threshold` field in `src/mnemonic/internal/mcpserver/input.go` from `(default 0.7)` to `(default 0.5)`
- Source of truth: `DefaultMCPDefaultSearchThreshold = 0.5` in `internal/config/defaults.go`

Fixes #73

🤖 Generated with [Claude Code](https://claude.ai/claude-code)