### PR TITLE
docs: add OpenAI model checks to health check documentation

### DIFF
--- a/docs/architecture/07-observability-architecture.md
+++ b/docs/architecture/07-observability-architecture.md
@@ -205,7 +205,9 @@ Mnemonic exposes a health check endpoint at `GET /health` on the Admin API (:808
 {
   "status": "healthy",
   "postgres": "reachable",
-  "neo4j": "reachable"
+  "neo4j": "reachable",
+  "openai_embedding_model": "reachable",
+  "openai_extraction_model": "reachable"
 }
 ```
 
@@ -215,11 +217,20 @@ Mnemonic exposes a health check endpoint at `GET /health` on the Admin API (:808
 {
   "status": "unhealthy",
   "postgres": "unreachable",
-  "neo4j": "reachable"
+  "neo4j": "reachable",
+  "openai_embedding_model": "reachable",
+  "openai_extraction_model": "reachable"
 }
 ```
 
-**Health determination:** Both Postgres and Neo4j must be reachable for the service to report healthy. A failure of either database results in an unhealthy response. The check performs a lightweight connectivity probe (ping or equivalent) against each database; it does not execute business logic.
+**Health determination:** The health check validates four dependencies. All four must pass for the service to report healthy. If any fails, the health endpoint returns an unhealthy status with details about which dependency is down.
+
+| Dependency | Check | Failure impact |
+|---|---|---|
+| PostgreSQL | `Ping()` | Pattern storage and search unavailable |
+| Neo4j | `VerifyConnectivity()` | Knowledge graph queries fail |
+| OpenAI embedding model | Model validation | New pattern enrichment fails |
+| OpenAI extraction model | Model validation | Concept extraction fails |
 
 **Logging:** Health check status changes (healthy → unhealthy, unhealthy → healthy) are logged as system events. Repeated healthy checks are not logged to avoid log noise.
 


### PR DESCRIPTION
## Summary

- Updated health check section in `docs/architecture/07-observability-architecture.md` to document all four dependency checks (PostgreSQL, Neo4j, OpenAI embedding model, OpenAI extraction model)
- Updated JSON response examples to include the two OpenAI model fields
- Added dependency table with check methods and failure impacts

Fixes #74

🤖 Generated with [Claude Code](https://claude.ai/claude-code)